### PR TITLE
Fix savannah.gnu.org timeout: gnulib repos is changed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = git://git.sv.gnu.org/autoconf-archive.git
 [submodule "dependencies/gnulib"]
 	path = dependencies/gnulib
-	url = git://git.savannah.gnu.org/gnulib.git
+	url = git://github.com/gagern/gnulib


### PR DESCRIPTION
git.savannah.gnu.org is often blocked and git clone does'n work. I suggest you to change the gnulib repository to another one hosted on github.