### PR TITLE
Update regexp to match for CentOS 7.0.1406

### DIFF
--- a/tasks/lib/distros.rb
+++ b/tasks/lib/distros.rb
@@ -47,7 +47,7 @@ def detect_distro
 
   # CentOS # TODO: Do not piggyback the :fedora version
   if File.exist? '/etc/redhat-release'
-    match = File.new('/etc/redhat-release').readline.match(/CentOS release (\S+)/)
+    match = File.new('/etc/redhat-release').readline.match(/CentOS.* release (\S+)/)
     if match
       release = match[1]
       return [:fedora, release]


### PR DESCRIPTION
I had to adjust this to get run `rake` in CentOS 7.0.1406.  I am running this in Docker with the latest CentOS image from DockerHub.
