### PR TITLE
Possibility to install last versions of OTP + disable SSL EC if needed

### DIFF
--- a/tasks/erlang.rake
+++ b/tasks/erlang.rake
@@ -48,7 +48,8 @@ namespace :erlang do
           ldflags = '-L/opt/csw/lib'
         end
 		if ENV['erl_cflags']
-			cflags += ' '+ENV['erl_cflags']
+			env_erl_cflags = ENV['erl_cflags']
+			cflags += " #{env_erl_cflags}"
 		end
 		
         configure = [


### PR DESCRIPTION
In the last version of OTP we don't have librairies appmon, toolbar, pman and tv any more. So a simple check for folder existance is added. (Bug fix #24 )
By if you want to use older version of OTP on CentOS 6.5 SSL EC must be disabled. I suggest to do it this way:
rake erl_cflags="-DOPENSSL_NO_EC=1" (Bug fix #26 )
